### PR TITLE
Fix index.json

### DIFF
--- a/docs/data/index.json
+++ b/docs/data/index.json
@@ -9,7 +9,7 @@
             "name": "Saadia Jameel",
             "email": "e18147@eng.pdn.ac.lk",
             "eNumber": "E/18/147"
-        },
+        }
     ],
     "supervisors": [
         {


### PR DESCRIPTION
api.ce.pdn.ac.lk failed to parse the index.json 
![image](https://github.com/cepdnaclk/e18-4yp-Neuromorphic-NoC-Architecture-for-SNNs/assets/73381996/6801bb28-2f05-41b6-b0df-8677428ce88a)

This happened because of the comma on the last item. Python doesnt support having the comma on the last item. This PR should fix the issue